### PR TITLE
Update link to interaction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ Now follow the [interaction instructions][interaction].
 
 [acceptance-test]:https://github.com/camelpunch/pong_matcher_acceptance
 [pws]:https://run.pivotal.io
-[interaction]:https://github.com/camelpunch/pong_matcher_grails#interaction-instructions
+[interaction]:https://github.com/cloudfoundry-samples/pong_matcher_rails/blob/master/README.md#interaction-instructions


### PR DESCRIPTION
Interaction instructions link was broken (pointed to non-existent "pong_matcher_grails" file in camelpuch repo.
